### PR TITLE
Use explicit hashes for enums

### DIFF
--- a/app/models/time_slot.rb
+++ b/app/models/time_slot.rb
@@ -15,5 +15,8 @@ class TimeSlot < ApplicationRecord
   has_one :reservation,    dependent: :destroy
   has_many :subscriptions, dependent: :destroy
 
-  enum status: [:vacant, :booked]
+  enum status: {
+    vacant: 0,
+    booked: 1
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,16 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
   has_many :comments,      dependent: :destroy
 
-  enum role: [:client, :owner, :admin]
-  enum notifications: ['do not notify', '15 minutes', '3 hours', '1 day']
+  enum role: {
+    client: 0,
+    owner: 1,
+    admin: 2
+  }
 
+  enum notifications: {
+    'do not notify': 0,
+    '15 minutes': 1,
+    '3 hours': 2,
+    '1 day': 3
+  }
 end


### PR DESCRIPTION
Changed enums in models user and time_slot to explicitly map attributes to integer values.